### PR TITLE
[FIX] UnboundLocalError in do_show command

### DIFF
--- a/console.py
+++ b/console.py
@@ -79,23 +79,26 @@ class HBNBCommand(cmd.Cmd):
         if len(args) == 0:
             print("** class name missing **")
         elif len(args) == 1:
-            print("** instance id missing **")
+            class_name = args[0]
+            global_namespace = globals()
+            if class_name not in global_namespace or not isinstance(global_namespace[class_name], type):
+                print("** class doesn't exist **")
+            else:
+                print("** instance id missing **")
         else:
             class_name = args[0]
             instance_id = args[1]
             global_namespace = globals()
-
-        if class_name not in global_namespace or not isinstance(global_namespace[class_name], type):
-            print("** class doesn't exist **")
-        else:
-            key = "{}.{}".format(class_name, instance_id)
-            all_instances = storage.all()
-            if key in all_instances:
-                print(all_instances[key])
+            if class_name not in global_namespace or not isinstance(global_namespace[class_name], type):
+                print("** class doesn't exist **")
             else:
-                print("** no instance found **")
-
-    
+                key = "{}.{}".format(class_name, instance_id)
+                all_instances = storage.all()
+                if key in all_instances:
+                    print(all_instances[key])
+                else:
+                    print("** no instance found **")
+  
     def do_destroy(self, arg):
         """
         Usage: destroy <class> <id>


### PR DESCRIPTION
Addresses an UnboundLocalError in the 'do_show' command of the HBnB console. The error occurred when the 'class_name' variable was referenced before assignment in the case where the class name is provided, but the instance ID is missing.

Changes made:
1. Moved the declaration of 'class_name' outside of the 'else' block to ensure its existence in the scope.
2. Reorganized the code structure to handle cases where the class name is provided, but the instance ID is missing, printing the appropriate error message.

This fix ensures that the 'do_show' command works correctly in scenarios where the class name is provided, but the instance ID is missing, preventing the UnboundLocalError.

Tested the modified code with the reported use cases to confirm the resolution.