### PR TITLE
[ADD] Retrieve Instances Using <class name>.all()

### DIFF
--- a/console.py
+++ b/console.py
@@ -154,20 +154,24 @@ class HBNBCommand(cmd.Cmd):
                 storage.save()
             else:
                 print("** no instance found **")
-
     def do_all(self, arg):
         """Display string representations of all instances."""
         argl = parse(arg)
+
         if len(argl) > 0 and argl[0] not in HBNBCommand.__classes:
             print("** class doesn't exist **")
         else:
-            objl = []
-            for obj in storage.all().values():
-                if len(argl) > 0 and argl[0] == obj.__class__.__name__:
-                    objl.append(obj.__str__())
-                elif len(argl) == 0:
-                    objl.append(obj.__str__())
-            print(objl)
+            class_name = argl[0] if len(argl) > 0 else None
+            obj_list = []
+
+            if class_name:
+                # Retrieve instances of a specific class
+                obj_list = [obj.__str__() for obj in storage.all().values() if isinstance(obj, globals()[class_name])]
+            else:
+                # Retrieve instances of all classes
+                obj_list = [obj.__str__() for obj in storage.all().values()]
+
+            print(obj_list)
 
     def do_count(self, arg):
         """Retrieve the number of instances of a given class."""


### PR DESCRIPTION
1. Modified the do_all method to check if a class name is provided as an argument.
2. If a class name is provided, it retrieves instances only for that specific class using <class name>.all().
3. If no class name is provided, it retrieves instances for all classes.
4. Dynamically accesses the class based on its name using globals()[class_name].
5. Populates obj_list with string representations of the instances.
6. Prints the list of instances at the end.